### PR TITLE
fix: move typscript to deps. Move types and Commitizen to dev deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,8 @@ jobs:
             - v1-npm-{{checksum ".circleci/config.yml"}}
       - run: &install_dependencies
           name: Install dependencies
-          command: yarn
+          # --ignore-engines is necessary for Commitizen to install with Node 8
+          command: yarn install --ignore-engines
       - run: ./bin/run --version
       - run: ./bin/run --help
       - run:

--- a/package.json
+++ b/package.json
@@ -13,34 +13,36 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^2",
-    "@types/express": "^4.17.0",
-    "@types/listr": "^0.14.1",
     "express": "^4.17.1",
     "fast-glob": "^3.0.4",
     "graphql": "^14.4.2",
     "listr": "^0.14.3",
     "open": "^6.4.0",
     "ramda": "^0.26.1",
-    "tslib": "^1"
+    "tslib": "^1",
+    "typescript": "^3.6.3"
   },
   "devDependencies": {
     "@babel/types": "^7.4.4",
     "@oclif/test": "^1.2.4",
     "@oclif/tslint": "^3",
+    "@types/express": "^4.17.1",
     "@types/graphql": "^14.2.2",
     "@types/jest": "^24.0.13",
+    "@types/listr": "^0.14.2",
     "@types/node": "^12.0.8",
     "@types/nodegit": "^0.24.8",
     "@types/ramda": "^0.26.15",
     "chai": "^4.2.0",
+    "commitizen": "^4.0.3",
+    "cz-conventional-changelog": "3.0.2",
     "jest": "^24.8.0",
     "prettier": "^1.18.2",
     "semantic-release": "^15.13.24",
     "ts-jest": "^24.0.2",
     "ts-node": "^8",
     "tslint": "^5",
-    "tslint-config-prettier": "^1.18.0",
-    "typescript": "^3.3"
+    "tslint-config-prettier": "^1.18.0"
   },
   "engines": {
     "node": ">=8.0.0"
@@ -74,9 +76,5 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
-  },
-  "optionalDependencies": {
-    "commitizen": "^4.0.3",
-    "cz-conventional-changelog": "^3.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -533,8 +533,8 @@
     "@babel/types" "^7.3.0"
 
 "@types/body-parser@*":
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.17.0.tgz#9f5c9d9bd04bb54be32d5eb9fc0d8c974e6cf58c"
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.17.1.tgz#18fcf61768fb5c30ccc508c21d6fd2e8b3bf7897"
   dependencies:
     "@types/connect" "*"
     "@types/node" "*"
@@ -554,15 +554,15 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
 
 "@types/express-serve-static-core@*":
-  version "4.16.7"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.16.7.tgz#50ba6f8a691c08a3dd9fa7fba25ef3133d298049"
+  version "4.16.9"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.16.9.tgz#69e00643b0819b024bdede95ced3ff239bb54558"
   dependencies:
     "@types/node" "*"
     "@types/range-parser" "*"
 
-"@types/express@^4.17.0":
-  version "4.17.0"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.0.tgz#49eaedb209582a86f12ed9b725160f12d04ef287"
+"@types/express@^4.17.1":
+  version "4.17.1"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.1.tgz#4cf7849ae3b47125a567dfee18bfca4254b88c5c"
   dependencies:
     "@types/body-parser" "*"
     "@types/express-serve-static-core" "*"
@@ -607,9 +607,9 @@
   dependencies:
     "@types/jest-diff" "*"
 
-"@types/listr@^0.14.1":
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/@types/listr/-/listr-0.14.1.tgz#ed55e083589c289774893fe1d582c3452eb11ca5"
+"@types/listr@^0.14.2":
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/@types/listr/-/listr-0.14.2.tgz#2e5f80fbc3ca8dceb9940ce9bf8e3113ab452545"
   dependencies:
     "@types/node" "*"
     rxjs "^6.5.1"
@@ -641,8 +641,8 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.8.tgz#e469b4bf9d1c9832aee4907ba8a051494357c12c"
 
 "@types/node@^12.0.2":
-  version "12.7.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.4.tgz#64db61e0359eb5a8d99b55e05c729f130a678b04"
+  version "12.7.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.5.tgz#e19436e7f8e9b4601005d73673b6dc4784ffcc2f"
 
 "@types/nodegit@^0.24.8":
   version "0.24.8"
@@ -667,8 +667,8 @@
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
 
 "@types/serve-static@*":
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.2.tgz#f5ac4d7a6420a99a6a45af4719f4dcd8cd907a48"
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.3.tgz#eb7e1c41c4468272557e897e9171ded5e2ded9d1"
   dependencies:
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
@@ -1653,7 +1653,7 @@ cz-conventional-changelog@3.0.1:
   optionalDependencies:
     "@commitlint/load" ">6.1.1"
 
-cz-conventional-changelog@^3.0.2:
+cz-conventional-changelog@3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/cz-conventional-changelog/-/cz-conventional-changelog-3.0.2.tgz#f6b9a406177ab07f9a3a087e06103a045b376260"
   dependencies:
@@ -5687,13 +5687,13 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs@^6.3.3, rxjs@^6.5.1:
+rxjs@^6.3.3:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.2.tgz#2e35ce815cd46d84d02a209fb4e5921e051dbec7"
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^6.4.0:
+rxjs@^6.4.0, rxjs@^6.5.1:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.3.tgz#510e26317f4db91a7eb1de77d9dd9ba0a4899a3a"
   dependencies:
@@ -6532,9 +6532,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^3.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+typescript@^3.6.3:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
 
 uglify-js@^3.1.4:
   version "3.6.0"


### PR DESCRIPTION
This change moves typescript to deps to to fix a bug where typescript could not be resolved when
graphql-usage was installed globally. This change also cleans up dependencies for types and
Commitizen. --ignore-engines has also been added to the install step on CI to prevent Commitzen to
cause yarn to throw errors when using Node 8.