### PR TITLE
fix: use yarn rather than npx for release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
       - run: *install_dependencies
       - run:
           name: Release package
-          command: npx semantic-release
+          command: yarn run semantic-release
 
 workflows:
   version: 2


### PR DESCRIPTION
This change updates CI to use yarn rather than npx to run semantic-release per the semantic-release docs.